### PR TITLE
Auto-install Husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "createrailsapp",
   "private": true,
   "scripts": {
+    "postinstall": "husky install",
     "lint": "bundle exec rubocop -P"
   },
   "dependencies": {


### PR DESCRIPTION
Husky is used to check files for errors/warnings pre-commit.
It will now automatically be added on nodes install